### PR TITLE
Implement non generic resolve. Simplify container interface

### DIFF
--- a/ManualDi.Main.Tests/TestDiContainerNonGenericResolve.cs
+++ b/ManualDi.Main.Tests/TestDiContainerNonGenericResolve.cs
@@ -1,0 +1,63 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace ManualDi.Main.Tests
+{
+    public class TestDiContainerNonGenericResolve
+    {
+        [Test]
+        public void TestResolveWithoutConstraint()
+        {
+            var container = new DiContainerBuilder().WithInstallDelegate(b =>
+            {
+                b.Bind<int>().FromInstance(5);
+            }).Build();
+
+            object resolved = container.Resolve(typeof(int));
+
+            Assert.That(resolved, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void TestResolveWithConstraint()
+        {
+            var container = new DiContainerBuilder().WithInstallDelegate(b =>
+            {
+                b.Bind<int>().FromInstance(2).WithMetadata("A");
+                b.Bind<int>().FromInstance(5).WithMetadata("B");
+            }).Build();
+
+            object resolved = container.Resolve(typeof(int), x => x.WhereMetadata("B"));
+
+            Assert.That(resolved, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void TestResolveAllWithoutConstraint()
+        {
+            var container = new DiContainerBuilder().WithInstallDelegate(b =>
+            {
+                b.Bind<int>().FromInstance(2);
+                b.Bind<int>().FromInstance(5);
+            }).Build();
+
+            List<object> resolved = container.ResolveAll(typeof(int));
+
+            Assert.That(resolved, Is.EquivalentTo(new[] { 2, 5 }));
+        }
+
+        [Test]
+        public void TestResolveAllWithConstraint()
+        {
+            var container = new DiContainerBuilder().WithInstallDelegate(b =>
+            {
+                b.Bind<int>().FromInstance(2).WithMetadata("A");
+                b.Bind<int>().FromInstance(5).WithMetadata("B");
+            }).Build();
+
+            List<object> resolved = container.ResolveAll(typeof(int), x => x.WhereMetadata("B"));
+
+            Assert.That(resolved, Is.EquivalentTo(new[] { 5 }));
+        }
+    }
+}

--- a/ManualDi.Main/DiContainerBindings.cs
+++ b/ManualDi.Main/DiContainerBindings.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ManualDi.Main
+{
+    public class DiContainerBindings : IDiContainerBindings
+    {
+        private readonly List<Action> disposeActions = new List<Action>();
+
+        public IReadOnlyList<Action> DisposeActions => disposeActions;
+        public Dictionary<Type, List<ITypeBinding>> TypeBindings { get; } = new Dictionary<Type, List<ITypeBinding>>();
+
+        public void AddBinding<T>(ITypeBinding<T> typeBinding)
+        {
+            Type type = typeof(T);
+            if (!TypeBindings.TryGetValue(type, out var bindings))
+            {
+                bindings = new List<ITypeBinding>();
+                TypeBindings[type] = bindings;
+            }
+
+            bindings.Add(typeBinding);
+        }
+
+        public void QueueDispose(Action action)
+        {
+            disposeActions.Add(action);
+        }
+    }
+}

--- a/ManualDi.Main/DiContainerResolutionExtensions.cs
+++ b/ManualDi.Main/DiContainerResolutionExtensions.cs
@@ -5,6 +5,44 @@ namespace ManualDi.Main
 {
     public static class DiContainerResolutionExtensions
     {
+        public static object Resolve(this IDiContainer diContainer, Type type)
+        {
+            return diContainer.Resolve(type, resolutionConstraints: null);
+        }
+
+        public static T Resolve<T>(this IDiContainer diContainer)
+        {
+            return diContainer.Resolve<T>(resolutionConstraints: null);
+        }
+
+        public static List<T> ResolveAll<T>(this IDiContainer diContainer)
+        {
+            var resolutions = new List<T>();
+            diContainer.ResolveAll<T>(resolutionConstraints: null, resolutions);
+            return resolutions;
+        }
+
+        public static List<T> ResolveAll<T>(this IDiContainer diContainer, IResolutionConstraints resolutionConstraints)
+        {
+            var resolutions = new List<T>();
+            diContainer.ResolveAll<T>(resolutionConstraints, resolutions);
+            return resolutions;
+        }
+
+        public static List<object> ResolveAll(this IDiContainer diContainer, Type type)
+        {
+            var resolutions = new List<object>();
+            diContainer.ResolveAll(type, resolutionConstraints: null, resolutions);
+            return resolutions;
+        }
+
+        public static List<object> ResolveAll(this IDiContainer diContainer, Type type, IResolutionConstraints resolutionConstraints)
+        {
+            var resolutions = new List<object>();
+            diContainer.ResolveAll(type, resolutionConstraints, resolutions);
+            return resolutions;
+        }
+
         public static T Resolve<T>(this IDiContainer diContainer, Action<IResolutionConstraints> resolution)
         {
             var resolutionConstraints = new ResolutionConstraints();
@@ -18,6 +56,21 @@ namespace ManualDi.Main
             var resolutionConstraints = new ResolutionConstraints();
             resolution.Invoke(resolutionConstraints);
             return diContainer.ResolveAll<T>(resolutionConstraints);
+        }
+
+        public static object Resolve(this IDiContainer diContainer, Type type, Action<IResolutionConstraints> resolution)
+        {
+            var resolutionConstraints = new ResolutionConstraints();
+            resolution.Invoke(resolutionConstraints);
+
+            return diContainer.Resolve(type, resolutionConstraints);
+        }
+
+        public static List<object> ResolveAll(this IDiContainer diContainer, Type type, Action<IResolutionConstraints> resolution)
+        {
+            var resolutionConstraints = new ResolutionConstraints();
+            resolution.Invoke(resolutionConstraints);
+            return diContainer.ResolveAll(type, resolutionConstraints);
         }
     }
 }

--- a/ManualDi.Main/IDiContainer.cs
+++ b/ManualDi.Main/IDiContainer.cs
@@ -5,12 +5,48 @@ namespace ManualDi.Main
 {
     public interface IDiContainer : IDisposable
     {
-        T Resolve<T>();
+        /// <summary>
+        /// Generic resolution of a binding for its registered instance
+        /// </summary>
+        /// <remarks>There are more versions of this Resolution using extension methods <see cref="DiContainerResolutionExtensions"/></remarks>
+        /// <typeparam name="T">The type of the binding to resolve</typeparam>
+        /// <param name="resolutionConstraints">Filter bindings to resolve according to these constraints. May be null</param>
+        /// <returns>The resolved instance for the binding</returns>
         T Resolve<T>(IResolutionConstraints resolutionConstraints);
 
-        List<T> ResolveAll<T>();
-        List<T> ResolveAll<T>(IResolutionConstraints resolutionConstraints);
+        /// <summary>
+        /// Non generic resolution of a binding for its registered instance
+        /// </summary>
+        /// <remarks>There are more versions of this Resolution using extension methods <see cref="DiContainerResolutionExtensions"/></remarks>
+        /// <param name="type">The type of the binding to resolve</param>
+        /// <param name="resolutionConstraints">Filter bindings to resolve according to these constraints. May be null</param>
+        /// <returns>The resolved instance for the binding</returns>
+        object Resolve(Type type, IResolutionConstraints resolutionConstraints);
 
+        /// <summary>
+        /// Generic resolution of all bindings for their registered instances
+        /// </summary>
+        /// <remarks>There are more versions of this Resolution using extension methods <see cref="DiContainerResolutionExtensions"/></remarks>
+        /// <typeparam name="T">The type of the binding to resolve</typeparam>
+        /// <param name="resolutionConstraints">Filter bindings to resolve according to these constraints. May be null</param>
+        /// <param name="resolutions">The list of resolutions to be populated from the operations done inside. Resolutions are added at the end of the list</param>
+        /// <returns>The resolved instances for the binding</returns>
+        void ResolveAll<T>(IResolutionConstraints resolutionConstraints, List<T> resolutions);
+
+        /// <summary>
+        /// Non generic resolution of all bindings for their registered instances
+        /// </summary>
+        /// <remarks>There are more versions of this Resolution using extension methods <see cref="DiContainerResolutionExtensions"/></remarks>
+        /// <param name="type">The type of the binding to resolve</param>
+        /// <param name="resolutionConstraints">Filter bindings to resolve according to these constraints. May be null</param>
+        /// <param name="resolutions">The list of resolutions to be populated from the operations done inside. Resolutions are added at the end of the list</param>
+        /// <returns>The resolved instances for the binding</returns>
+        void ResolveAll(Type type, IResolutionConstraints resolutionConstraints, List<object> resolutions);
+
+        /// <summary>
+        /// Queues for disposal an action. They will be called in order when disposing the container.
+        /// </summary>
+        /// <param name="disposeAction">The action to call when disposing</param>
         void QueueDispose(Action disposeAction);
     }
 }

--- a/ManualDi.Main/IResolution.cs
+++ b/ManualDi.Main/IResolution.cs
@@ -6,6 +6,6 @@ namespace ManualDi.Main
     {
         Func<ITypeMetadata, bool> TypeMetadata { get; set; }
 
-        bool Accepts<T>(ITypeBinding<T> typeBinding);
+        bool Accepts(ITypeBinding typeBinding);
     }
 }

--- a/ManualDi.Main/ManualDi.Main.csproj
+++ b/ManualDi.Main/ManualDi.Main.csproj
@@ -7,7 +7,7 @@
     <StartupObject />
     <AssemblyName>ManualDi.Main</AssemblyName>
     <RootNamespace>ManualDi.Main</RootNamespace>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <Authors>Pere Viader</Authors>
     <RepositoryUrl>https://github.com/PereViader/ManualDi.Main</RepositoryUrl>
     <Product>ManualDi.Main</Product>

--- a/ManualDi.Main/ResolutionConstraints.cs
+++ b/ManualDi.Main/ResolutionConstraints.cs
@@ -6,7 +6,7 @@ namespace ManualDi.Main
     {
         public Func<ITypeMetadata, bool> TypeMetadata { get; set; }
 
-        public bool Accepts<T>(ITypeBinding<T> typeBinding)
+        public bool Accepts(ITypeBinding typeBinding)
         {
             if (TypeMetadata == null)
             {


### PR DESCRIPTION
Resolves #2 

Adding non-generic methods, made the container interface too large.
Removed most of the methods and moved the parameter permutations to extension methods.